### PR TITLE
Bump v3.7.0 build number to 1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ hash }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:


### PR DESCRIPTION
…to fix build failure.

1. Before merging #29 all checks passed, including [this Azure Pipelines run](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=708230&view=results).
2. After merging, the "Current build status / All platforms:" shows "failed", with a link to [this Azure Pipelines run](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=708236&view=results).

In particular, the failure in (2) is [here](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=708236&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d&l=863):
```
KeyError: Dist(channel='conda-forge', dist_name='genno-1.17.0-pyhd8ed1ab_0', name='genno', fmt='.conda', version='1.17.0', build_string='pyhd8ed1ab_0', build_number=0, base_url=None, platform=None)
```
…whereas in (1), [here](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=708230&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d&l=932) we see:
```
genno:                         1.16.1-pyhd8ed1ab_0         conda-forge
```
…so the culprit may be conda-forge/genno-feedstock#22.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Ensured the license file is being packaged.